### PR TITLE
Use newer version of Scala, ScalaTest, and the Android sbt plugin

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,8 +1,8 @@
 name=My Android Project
 api_level=10
-scala_version=2.9.1
+scala_version=2.9.2
 main_activity=MainActivity
 package=my.android.project
 description=Template for Android apps in Scala
 useProguard=true
-scalatest_version=1.8.RC1
+scalatest_version=1.8

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.url("scalasbt releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.1")
+addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.2")


### PR DESCRIPTION
Version 0.6.1 of the sbt android plugin seems to no longer be available in the repo, so I updated it to 0.6.2.  I updated the default Scala and ScalaTest versions to the latest stable ones as well.
