### PR TITLE
require sbt 0.12.0

### DIFF
--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.0
+

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.url("scalasbt releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.2")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")


### PR DESCRIPTION
template now has build.properties that requires sbt version 0.12.0
this is donefor compatibility reasons as template does not compile
under sbt version 0.12.1 due to unresolved dependencies
