### PR TITLE
allow default options to build

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,4 @@
-name=My Android Project
+name=MyAndroidProject
 api_level=10
 scala_version=2.9.2
 main_activity=MainActivity


### PR DESCRIPTION
Spaces in the name didn't work for SBT - seems like the default options should build
