### PR TITLE
Enable using JDK 1.7

### DIFF
--- a/src/main/g8/project/Build.scala
+++ b/src/main/g8/project/Build.scala
@@ -9,7 +9,8 @@ object General {
     version := "0.1",
     versionCode := 0,
     scalaVersion := "$scala_version$",
-    platformName in Android := "android-$api_level$"
+    platformName in Android := "android-$api_level$",
+    javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6")
   )
 
   val proguardSettings = Seq (


### PR DESCRIPTION
Proguard chokes on JDK 1.7, this commit fixes the issue by explicitly targeting JDK 1.6. 

Tested on Fedora 17 x86_64 openjdk-1.7.0.9-2.3.8.0.fc17.x86_64.

Hope this helps.
