### PR TITLE
Added sbt-idea dependency

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.url("scalasbt releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.2")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")


### PR DESCRIPTION
Typing 'sbt gen-idea' generates errors like following:

[error] Not a valid command: gen-idea
[error] Not a valid project ID: gen-idea
[error] Expected ':'
[error] Not a valid key: gen-idea
[error] gen-idea
[error]         ^

To fix this, added 'sbt-idea' plug-in settings to 'plugins.sbt' file.
